### PR TITLE
Added test

### DIFF
--- a/test/freq_handler/eventIn.json
+++ b/test/freq_handler/eventIn.json
@@ -1,0 +1,26 @@
+[
+    {
+        "frameOffset": 10,
+        "event": {
+            "channel": 1,
+            "pitch": 69,
+            "velocity": 1
+        }
+    },
+    {
+        "frameOffset": 20,
+        "event": {
+            "channel": 1,
+            "pitch": 57,
+            "velocity": 1
+        }
+    },
+    {
+        "frameOffset": 50,
+        "event": {
+            "channel": 1,
+            "pitch": 69,
+            "velocity": 1
+        }
+    }
+]

--- a/test/freq_handler/expectedOutput-console.json
+++ b/test/freq_handler/expectedOutput-console.json
@@ -1,0 +1,42 @@
+[
+    {
+        "frameOffset": 10,
+        "event": 0.0
+    },
+    {
+        "frameOffset": 10,
+        "event": 440
+    },
+    {
+        "frameOffset": 20,
+        "event": 0.0
+    },
+    {
+        "frameOffset": 20,
+        "event": 220
+    },
+    {
+        "frameOffset": 30,
+        "event": 1.5
+    },
+    {
+        "frameOffset": 30,
+        "event": 220
+    },
+    {
+        "frameOffset": 40,
+        "event": 3
+    },
+    {
+        "frameOffset": 40,
+        "event": 220
+    },
+    {
+        "frameOffset": 50,
+        "event": 3
+    },
+    {
+        "frameOffset": 50,
+        "event": 440
+    }
+]

--- a/test/freq_handler/expectedOutput-frequencyOut.json
+++ b/test/freq_handler/expectedOutput-frequencyOut.json
@@ -1,0 +1,22 @@
+[
+    {
+        "frameOffset": 10,
+        "event": 440
+    },
+    {
+        "frameOffset": 20,
+        "event": 220
+    },
+    {
+        "frameOffset": 30,
+        "event": 221.5
+    },
+    {
+        "frameOffset": 40,
+        "event": 223
+    },
+    {
+        "frameOffset": 50,
+        "event": 443
+    }
+]

--- a/test/freq_handler/osc1Freq.json
+++ b/test/freq_handler/osc1Freq.json
@@ -1,0 +1,10 @@
+[
+    {
+        "frameOffset": 30,
+        "event": 100
+    },
+    {
+        "frameOffset": 40,
+        "event": 200
+    }
+]

--- a/test/test.cmajtest
+++ b/test/test.cmajtest
@@ -1,0 +1,26 @@
+
+
+## runScript ({ sampleRate:44100, blockSize:32, samplesToRender:100, subDir:"freq_handler" })
+
+processor FreqHandler
+{
+    input event (std::notes::NoteOn,std::notes::NoteOff) eventIn;
+    input event float osc1Freq;
+    output event float frequencyOut;
+
+    float processedFreq = 0.0f;
+    float noteFreq = 0.0f;
+    let freqFactor  = 1.5f;
+
+    event osc1Freq (float newFreq)  {
+        processedFreq = newFreq * freqFactor / 100.0f;
+        frequencyOut <- processedFreq + noteFreq;
+        console <- processedFreq <- noteFreq;
+    }
+
+    event eventIn (std::notes::NoteOn e) {
+        noteFreq = std::notes::noteToFrequency (e.pitch);
+        frequencyOut <- noteFreq + processedFreq;
+        console <- processedFreq <- noteFreq;
+    }
+}


### PR DESCRIPTION
I've added a cmajtest file which can be run by executing 'cmaj test synthcmajor/test/test.cmajtest' or by opening and running them from within vscode (e.g. opening the test.cmajtest file and pressing F5)

The test contains the FreqHandler processor you are working on, and the test/freq_handler directory contains input and output events which the test will apply to the processor at the frame offsets indicated. The expectedOutput files are generated by running the test (or checked that they contain the expected results if they already exist).

In this case i've submitted three NoteOn events, corresponding to note 69 (which has a known frequency of 440) and then 57 (440 / 2 = 220) and then 69 again, at frames 10, 20 and 50

Meanwhile osc1Freq updates are applied at frames 30 and 40 with values 100 and 200.

I modified the processor to include writing output to console which means you can see the values of the processorFreq and noteFreq when the event handlers are called.

If you check the console expected output and frequencyOut you see the values output. It looks to me like things are working correctly, but this may not be the logic you want.